### PR TITLE
Added the ability to display an ACF field with separators. 

### DIFF
--- a/archivist.php
+++ b/archivist.php
@@ -811,6 +811,11 @@ if ( ! class_exists( 'archivist' ) ) {
 								  			'<a href="https://www.advancedcustomfields.com" target="_blank">ACF</a>',
 								  			'<a href="https://www.advancedcustomfields.com/resources/get_field/" target="_blank"><pre>get_field()</pre></a>'
 								  		); ?> <br/>
+									<pre>%ACF|field_name|...%</pre><br/><?php echo sprintf(
+								  		__( 'Display %s list, separated by custom HTML. Uses the %s function.', 'archivist' ),
+								  			'<a href="https://www.advancedcustomfields.com" target="_blank">ACF</a>',
+								  			'<a href="https://www.advancedcustomfields.com/resources/get_field/" target="_blank"><pre>get_field()</pre></a>'
+								  		); ?> <br/>
 								</p>
 							</div>
 

--- a/parser.php
+++ b/parser.php
@@ -15,7 +15,7 @@ class Archivist_Parser {
 	
 	private function replace_categories( $matches ) {
 		return get_the_category_list( $matches[ 1 ] );
-    }
+	}
 
 	private function replace_post_meta_with_separator( $matches ) {
 		$list = get_post_meta( $this->post->ID, $matches[ 1 ], false );
@@ -26,6 +26,16 @@ class Archivist_Parser {
 		return get_post_meta( $this->post->ID, $matches[ 1 ], true );
 	}
 
+	private function replace_acf_with_separator( $matches ) {
+
+		if ( ! function_exists( 'get_field' ) ) {
+			return;
+		}
+
+		$list = get_field( $matches[ 1 ], $this->post->ID );
+		return implode( $matches[ 2 ], $list );
+
+	}
 	private function replace_acf_field( $matches ) {
 		
 		if ( ! function_exists( 'get_field' ) ) {
@@ -103,6 +113,13 @@ class Archivist_Parser {
 		$this->template = preg_replace_callback(
 		    '/%POST_THUMBNAIL\|(\d+)x(\d+)%/',
 		    array( $this, 'replace_thumbnails' ),
+		 	$this->template
+		 );
+
+		// acf field with separator
+		$this->template = preg_replace_callback(
+		    '/%ACF\|(.*?)\|(.*)%/',
+		    array( $this, 'replace_acf_with_separator' ),
 		 	$this->template
 		 );
 


### PR DESCRIPTION
Useful for checkboxes and selectors with multiple results (arrays).

After posting a questio to the WP plugin forum recently about this I decided to dig in and make it happen myself. Here's my modified code. Please look it over and bring it in to Archivist on the chance that someone else can make use of these changes with ACF.